### PR TITLE
Fix rust workflows running twice in PR

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,5 +1,10 @@
 # Copied from https://github.com/rerun-io/rerun_template
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    types: [ opened, synchronize ]
 
 name: Link checker
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,10 @@
 # Copied from https://github.com/rerun-io/rerun_template
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    types: [opened, synchronize]
 
 name: Rust
 


### PR DESCRIPTION
Some workflows were running both on push (to all branches) and on PR changes, both of which happen when you push to a PR. Now push is restricted to `main`.
