### PR TITLE
Fix ghost column when no sticky columns

### DIFF
--- a/egui_table/src/table.rs
+++ b/egui_table/src/table.rs
@@ -618,7 +618,7 @@ impl<'a> TableSplitScrollDelegate<'a> {
         // Used to find the visible range of columns and rows:
         let viewport = ui.clip_rect().translate(offset);
 
-        let col_range = if self.table.columns.is_empty() {
+        let col_range = if self.table.columns.is_empty() || viewport.left() == viewport.right() {
             0..0
         } else if self.do_full_sizing_pass {
             // We do the UI for all columns during a sizing pass, so we can auto-size ALL columns
@@ -635,7 +635,7 @@ impl<'a> TableSplitScrollDelegate<'a> {
             col_idx_at(viewport.min.x)..col_idx_at(viewport.max.x) + 1
         };
 
-        let row_range = if self.table.num_rows == 0 {
+        let row_range = if self.table.num_rows == 0 || viewport.top() == viewport.bottom() {
             0..0
         } else {
             // Only paint the visible rows:


### PR DESCRIPTION
When no sticky columns are present, an extra "ghost" column appears because of a fault in the code that determines which columns to render for the bottom left portion of `SplitScroll`. When the bottom left portion has zero width, it claims it should render columns `0..1`, while the correct result is `0..0`.
I applied the same fix for sticky rows.

See faulty behavior in video:

https://github.com/user-attachments/assets/73838349-44ba-4c21-8fc9-0e922a2f6f44


