### PR TITLE
[Feat] Add `Fill` variant

### DIFF
--- a/demo/src/table_demo.rs
+++ b/demo/src/table_demo.rs
@@ -250,6 +250,11 @@ impl TableDemo {
                     egui_table::AutoSizeMode::OnParentResize,
                     "OnParentResize",
                 );
+                ui.radio_value(
+                    &mut self.auto_size_mode,
+                    egui_table::AutoSizeMode::Fill,
+                    "Fill",
+                );
             });
             ui.end_row();
         });

--- a/egui_table/src/table.rs
+++ b/egui_table/src/table.rs
@@ -22,6 +22,9 @@ pub enum AutoSizeMode {
 
     /// Auto-size the columns if the parents' width changes
     OnParentResize,
+
+    /// Auto-size the columns only if the parents' width is greater than the minimum width
+    Fill,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -375,6 +378,9 @@ impl Table {
             AutoSizeMode::Never => false,
             AutoSizeMode::Always => true,
             AutoSizeMode::OnParentResize => state.parent_width.map_or(true, |w| w != parent_width),
+            AutoSizeMode::Fill => state.parent_width.map_or(true, |w| {
+                w > self.columns.iter().map(|col| col.current).sum()
+            }),
         };
         if auto_size {
             Column::auto_size(&mut self.columns, parent_width);


### PR DESCRIPTION
<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->

Add a new variant to `AutoSizeMode` that adjusts the columns to either fit the parent ui width or stay sized as they are depending on if the parent ui is wider than the current total width.

Somewhere between `AutoSizeMode::Never` and `AutoSizeMode::Always`.
