### PR TITLE
[Fix] `push_id()` for ui sections in table

### DIFF
--- a/egui_table/src/table.rs
+++ b/egui_table/src/table.rs
@@ -772,23 +772,31 @@ impl<'a> SplitScrollDelegate for TableSplitScrollDelegate<'a> {
             ui.scroll_to_rect(target_rect, target_align);
         }
 
-        self.region_ui(ui, ui.clip_rect().min - ui.min_rect().min, true);
+        ui.push_id("right_bottom", |ui| {
+            self.region_ui(ui, ui.clip_rect().min - ui.min_rect().min, true);
+        });
     }
 
     fn left_top_ui(&mut self, ui: &mut Ui) {
-        self.header_ui(ui, Vec2::ZERO);
+        ui.push_id("left_top", |ui| {
+            self.header_ui(ui, Vec2::ZERO);
+        });
     }
 
     fn right_top_ui(&mut self, ui: &mut Ui) {
-        self.header_ui(ui, vec2(ui.clip_rect().min.x - ui.min_rect().min.x, 0.0));
+        ui.push_id("right_top", |ui| {
+            self.header_ui(ui, vec2(ui.clip_rect().min.x - ui.min_rect().min.x, 0.0));
+        });
     }
 
     fn left_bottom_ui(&mut self, ui: &mut Ui) {
-        self.region_ui(
-            ui,
-            vec2(0.0, ui.clip_rect().min.y - ui.min_rect().min.y),
-            false,
-        );
+        ui.push_id("left_bottom", |ui| {
+            self.region_ui(
+                ui,
+                vec2(0.0, ui.clip_rect().min.y - ui.min_rect().min.y),
+                false,
+            );
+        });
     }
 
     fn finish(&mut self, ui: &mut Ui) {


### PR DESCRIPTION
<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->

Fixes what I would consider a bug with adding anything requiring a salt to a region of the table that is not the bottom right.
This is due to the nature of reusing the `header_ui()` and `region_ui()` functions.