### PR TITLE
Make it easy to run changelog with uv

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,9 +1,10 @@
 # Release Checklist
 
-* [ ] Update `CHANGELOG.md` using `./scripts/generate_changelog.py --version 0.NEW.VERSION`
+* [ ] Update `CHANGELOG.md` using `uv run scripts/generate_changelog.py --version 0.NEW.VERSION`
 * [ ] Bump version numbers in `Cargo.toml` and run `cargo check`.
 * [ ] `git commit -m 'Release 0.x.0 - summary'`
 * [ ] `cargo publish --quiet -p egui_table`
 * [ ] `git tag -a 0.x.0 -m 'Release 0.x.0 - summary'`
-* [ ] `git pull --tags ; git tag -d latest && git tag -a latest -m 'Latest release' && git push --tags origin latest --force ; git push --tags`
+* [ ] 
+  `git pull --tags ; git tag -d latest && git tag -a latest -m 'Latest release' && git push --tags origin latest --force ; git push --tags`
 * [ ] Do a GitHub release: https://github.com/rerun-io/egui_table/releases/new

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,12 +1,18 @@
-#!/usr/bin/env python3
-# Copied from https://github.com/rerun-io/rerun_template
-
 """
 Summarizes recent PRs based on their GitHub labels.
 
 The result can be copy-pasted into CHANGELOG.md,
 though it often needs some manual editing too.
 """
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "requests",
+#     "GitPython",
+#     "tqdm",
+# ]
+# ///
 
 from __future__ import annotations
 
@@ -106,7 +112,7 @@ def get_commit_info(commit: Any) -> CommitInfo:
 
 def remove_prefix(text: str, prefix: str) -> str:
     if text.startswith(prefix):
-        return text[len(prefix) :]
+        return text[len(prefix):]
     return text  # or whatever
 
 


### PR DESCRIPTION
We can now just `uv run scripts/generate_changelog.py --version 0.NEW.VERSION`. uv is great.