### PR TITLE
Add `stick_to_bottom` flag to Table and SplitScroll

### DIFF
--- a/demo/src/split_scroll_demo.rs
+++ b/demo/src/split_scroll_demo.rs
@@ -15,6 +15,7 @@ impl SplitScrollDemo {
             fixed_size: vec2(123.0, 37.0),
             scroll_outer_size: vec2(600.0, 400.0),
             scroll_content_size: vec2(10_000.0, 10_000.0),
+            stick_to_bottom: false,
         }
         .show(ui, &mut delegate);
     }

--- a/egui_table/src/split_scroll.rs
+++ b/egui_table/src/split_scroll.rs
@@ -35,6 +35,9 @@ pub struct SplitScroll {
 
     /// Size of the large contents of the right bottom region, ignoring the left/top fixed regions.
     pub scroll_content_size: Vec2,
+
+    /// If true, the vertical scrollbar will stick to the bottom as the content grows.
+    pub stick_to_bottom: bool,
 }
 
 /// The contents of a [`SplitScroll`].
@@ -64,6 +67,7 @@ impl SplitScroll {
             fixed_size,
             scroll_outer_size,
             scroll_content_size,
+            stick_to_bottom,
         } = self;
 
         ui.scope(|ui| {
@@ -88,6 +92,7 @@ impl SplitScroll {
                 egui::ScrollArea::new(scroll_enabled)
                     .auto_shrink(false)
                     .scroll_bar_rect(bottom_right_rect)
+                    .stick_to_bottom(stick_to_bottom)
                     .show_viewport(&mut scroll_ui, |ui, scroll_offset| {
                         ui.set_min_size(fixed_size + scroll_content_size);
 

--- a/egui_table/src/table.rs
+++ b/egui_table/src/table.rs
@@ -118,6 +118,11 @@ pub struct Table {
 
     scroll_to_columns: Option<(RangeInclusive<usize>, Option<Align>)>,
     scroll_to_rows: Option<(RangeInclusive<u64>, Option<Align>)>,
+
+    /// If true, the vertical scrollbar will stick to the bottom as the content grows.
+    ///
+    /// Useful for log views or terminal emulation.
+    stick_to_bottom: bool,
 }
 
 impl Default for Table {
@@ -131,6 +136,7 @@ impl Default for Table {
             auto_size_mode: AutoSizeMode::default(),
             scroll_to_columns: None,
             scroll_to_rows: None,
+            stick_to_bottom: false,
         }
     }
 }
@@ -274,6 +280,18 @@ impl Table {
     #[inline]
     pub fn auto_size_mode(mut self, auto_size_mode: AutoSizeMode) -> Self {
         self.auto_size_mode = auto_size_mode;
+        self
+    }
+
+    /// The scroll handle will stick to the bottom position even while the content size
+    /// changes dynamically.
+    ///
+    /// This can be useful to simulate terminal UIs or log/info scrollers.
+    /// The scroll handle remains stuck until user manually changes position. Once "unstuck"
+    /// it will remain focused on whatever content viewport the user left it on.
+    #[inline]
+    pub fn stick_to_bottom(mut self, stick: bool) -> Self {
+        self.stick_to_bottom = stick;
         self
     }
 
@@ -455,6 +473,7 @@ impl Table {
                             .sum(),
                         self.get_row_top_offset(ui.ctx(), id, table_delegate, self.num_rows),
                     ),
+                    stick_to_bottom: self.stick_to_bottom,
                 }
                 .show(
                     ui,


### PR DESCRIPTION
The functionality is already available on ScrollArea, so this commit is just introducing a way to configure that on the underline scroll area.

This is introducing another breaking change on `ScrollArea` since all of its fields are public. However this can be avoided in case #46 is resolved before merging this PR 

I didn't introduce a `stick_to_right` flag because I don't see it as relevant for table views.

No Changes added to Demo as it doesn't include growing content  

<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->

* Closes #ISSUE_NUMBER
