### PR TITLE
Prevent the number of columns to do below 12 in demo

### DIFF
--- a/demo/src/table_demo.rs
+++ b/demo/src/table_demo.rs
@@ -208,7 +208,7 @@ impl TableDemo {
     pub fn ui(&mut self, ui: &mut egui::Ui) {
         egui::Grid::new("settings").show(ui, |ui| {
             ui.label("Columns");
-            ui.add(egui::DragValue::new(&mut self.num_columns));
+            ui.add(egui::DragValue::new(&mut self.num_columns).range(12..=usize::MAX));
             ui.end_row();
 
             ui.label("Rows");


### PR DESCRIPTION
This is a **quick fix** for the demo as it would crash if the `DragValue` went below `12`.

This is because the `groups` are hard coded as:
```
egui_table::HeaderRow {
    height: self.top_row_height,
    groups: vec![0..1, 1..4, 4..8, 8..12],
},
```

This is really a minimal fix, to prevent the demo from crashing (wasm and native).

I think it's more a bug of the demo rather than an issue with the crate, hence this quick fix rather than a more extensive-logic change in the demo...


The app crash in 
```
egui_table::table::TableSplitScrollDelegate
fn header_ui(&mut self, ui: &mut Ui, offset: Vec2)
```

because `groups` would become stale, because of how their are calculated:
```
            let groups = if !header_row.groups.is_empty()
                && header_row
                    .groups
                    .iter()
                    .all(|g| g.end <= num_columns)
            {
                header_row.groups.clone()
            } else {
                (0..num_columns).map(|i| i..i + 1).collect()
            };
```

<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->

* Closes #23
