### PR TITLE
Stop the link checker failing on the docs.rs badge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -30,8 +30,12 @@ all-features = true
 
 [advisories]
 version = 2
+# Stale ignores fail CI rather than warn, so the entries below cannot rot silently.
+unused-ignored-advisory = "deny"
 ignore = [
-  "RUSTSEC-2024-0436", # unmaintained paste pulled via metal/wgpu, see https://github.com/gfx-rs/metal-rs/issues/349
+  # `paste` is gone from the lockfile, so its ignore was removed rather than carried.
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.38.4 via zbus_xml 5.1.0 -> zbus-lockstep -> atspi-common -> accesskit, and 0.39.2 via wayland-scanner (a proc-macro, so build-time only). Both reach only the `demo` crate, which is `publish = false`; `cargo tree -p egui_table` pulls neither. Blocked by zbus_xml requiring ^0.38 and wayland-scanner requiring ^0.39, while the fix is >=0.41.0. Remove when both move to quick-xml 0.41 and we re-lock. No ticket yet." },
+  { id = "RUSTSEC-2026-0195", reason = "Same two quick-xml paths, same blockers and same exit as RUSTSEC-2026-0194 above: reaches only the unpublished `demo` crate, and 0.41.0 is unreachable while zbus_xml pins ^0.38 and wayland-scanner pins ^0.39. No ticket yet." },
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -33,9 +33,8 @@ version = 2
 # Stale ignores fail CI rather than warn, so the entries below cannot rot silently.
 unused-ignored-advisory = "deny"
 ignore = [
-  # `paste` is gone from the lockfile, so its ignore was removed rather than carried.
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.38.4 via zbus_xml 5.1.0 -> zbus-lockstep -> atspi-common -> accesskit, and 0.39.2 via wayland-scanner (a proc-macro, so build-time only). Both reach only the `demo` crate, which is `publish = false`; `cargo tree -p egui_table` pulls neither. Blocked by zbus_xml requiring ^0.38 and wayland-scanner requiring ^0.39, while the fix is >=0.41.0. Remove when both move to quick-xml 0.41 and we re-lock. No ticket yet." },
-  { id = "RUSTSEC-2026-0195", reason = "Same two quick-xml paths, same blockers and same exit as RUSTSEC-2026-0194 above: reaches only the unpublished `demo` crate, and 0.41.0 is unreachable while zbus_xml pins ^0.38 and wayland-scanner pins ^0.39. No ticket yet." },
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.38.4 via zbus_xml 5.1.0 -> zbus-lockstep -> atspi-common -> accesskit, and 0.39.2 via wayland-scanner (a proc-macro, so build-time only). Both reach only the `demo` crate, which is `publish = false`; `cargo tree -p egui_table` pulls neither. Blocked by zbus_xml requiring ^0.38 and wayland-scanner requiring ^0.39, while the fix is >=0.41.0. Remove when both move to quick-xml 0.41 and we re-lock." },
+  { id = "RUSTSEC-2026-0195", reason = "Same two quick-xml paths, same blockers and same exit as RUSTSEC-2026-0194 above: reaches only the unpublished `demo` crate, and 0.41.0 is unreachable while zbus_xml pins ^0.38 and wayland-scanner pins ^0.39." },
 ]
 
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,9 +14,8 @@
 # Note that by default lychee will only check markdown and html files,
 # to check any other files you have to point to them explicitly, e.g.:
 # `lychee **/*.rs`
-# To make things worse, `exclude_path` is ignored for these globs,
-# so local runs with lots of gitignored files will be slow.
-# (https://github.com/lycheeverse/lychee/issues/1405)
+# `exclude_path` applies to those globs too, as of lychee 0.18
+# (https://github.com/lycheeverse/lychee/issues/1405).
 #
 # This unfortunately doesn't list anything for non-glob checks.
 ################################################################################
@@ -44,6 +43,9 @@ exclude_path = [
   "target_wasm",
   "target",
   "venv",
+
+  # This file. The `exclude` patterns below are not links to check.
+  "lychee.toml",
 ]
 
 # Exclude URLs and mail addresses from checking (supports regex).
@@ -75,9 +77,7 @@ exclude = [
   'https://github.com/rerun-io/egui_table/pull/\.*',   # Ignore links to our own pull requests (typically in changelog).
   'https://www.unicode.org/.*',                        # Avoid unicode.org rate-limiting
 
-  # Badge images. These are generated on demand and time out under load; a 408 from one
-  # says nothing about link rot. The pages they link *to* are still checked.
-  # NB: this file is itself link-checked, so the pattern has to match its own text —
-  # an escaped `\.` would not, and lychee would try to fetch the pattern.
-  'https://docs.rs/.*badge.*',
+  # Badge images are generated on demand and time out under load; a 408 says nothing
+  # about link rot. The pages they link *to* are still checked.
+  'https://docs\.rs/.*/badge\.svg',
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -74,4 +74,10 @@ exclude = [
   'https://github.com/rerun-io/egui_table/commit/\.*', # Ignore links to our own commits (typically in changelog).
   'https://github.com/rerun-io/egui_table/pull/\.*',   # Ignore links to our own pull requests (typically in changelog).
   'https://www.unicode.org/.*',                        # Avoid unicode.org rate-limiting
+
+  # Badge images. These are generated on demand and time out under load; a 408 from one
+  # says nothing about link rot. The pages they link *to* are still checked.
+  # NB: this file is itself link-checked, so the pattern has to match its own text —
+  # an escaped `\.` would not, and lychee would try to fetch the pattern.
+  'https://docs.rs/.*badge.*',
 ]


### PR DESCRIPTION
The link check has been red on `main` since 2026-06-26. The only error is `https://docs.rs/egui_table/badge.svg` returning 408 Request Timeout — the badge is generated on demand and times out under load. It answers 301 in ~20ms today, so this was transient, and `main` has stayed red only because nothing has been pushed since.

Excluding the badge image, not the link. `https://docs.rs/egui_table`, which the badge points at, is still checked. `egui_tiles` carries the same badge and will want the same line if it ever trips.

cargo deny failed, bump one dependency and allow one that doesn't end up in the shipped crate.

🤖 Opened by a coding agent (Claude Opus 5) on Ryan's behalf.
